### PR TITLE
Add chat UI components

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1,0 +1,43 @@
+<script lang="ts">
+  import { onMount, tick } from 'svelte';
+  import { messages, sendMessage, type Message } from '$lib/stores/messages';
+  import MessageItem from './MessageItem.svelte';
+  import MessageInput from './MessageInput.svelte';
+
+  // Hard coded identifiers for now
+  const chatId = 'chat-001';
+  const userId = 'user-abc';
+
+  // Reference to the scrolling container
+  let listEl: HTMLDivElement;
+
+  // Scroll to the bottom whenever messages change
+  $: scrollToBottom();
+  async function scrollToBottom() {
+    await tick();
+    listEl?.scrollTo({ top: listEl.scrollHeight, behavior: 'smooth' });
+  }
+
+  // Forward sent messages to the store
+  function handleSend(event: CustomEvent<string>) {
+    sendMessage(event.detail, chatId, userId);
+  }
+</script>
+
+<!-- Full screen chat container -->
+<div class="flex flex-col h-screen max-w-screen-md mx-auto">
+  <!-- Messages list -->
+  <div
+    class="overflow-y-auto px-4 py-2 flex-1"
+    bind:this={listEl}
+  >
+    {#each $messages as message (message.id)}
+      <MessageItem {message} />
+    {/each}
+  </div>
+
+  <!-- Input area -->
+  <div class="sticky bottom-0 bg-background px-4 py-3">
+    <MessageInput on:send={handleSend} />
+  </div>
+</div>

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1,0 +1,52 @@
+<script lang="ts">
+  import { createEventDispatcher } from 'svelte';
+
+  // Dispatcher emits the input string when a message is sent
+  const dispatch = createEventDispatcher<{ send: string }>();
+
+  let input = '';
+  let textareaEl: HTMLTextAreaElement;
+
+  // Auto resize the textarea to fit its content
+  function resize() {
+    textareaEl.style.height = 'auto';
+    textareaEl.style.height = textareaEl.scrollHeight + 'px';
+  }
+
+  // Handle keyboard shortcuts
+  function handleKeydown(event: KeyboardEvent) {
+    if (event.key === 'Enter' && !event.shiftKey) {
+      event.preventDefault();
+      send();
+    }
+  }
+
+  // Send the current input value
+  function send() {
+    const trimmed = input.trim();
+    if (trimmed) {
+      dispatch('send', trimmed);
+      input = '';
+      resize();
+    }
+  }
+</script>
+
+<!-- Input area with textarea and send button -->
+<div class="flex gap-2">
+  <textarea
+    class="flex-1 textarea rounded-md p-2 border bg-background text-sm sm:text-base"
+    bind:value={input}
+    on:input={resize}
+    on:keydown={handleKeydown}
+    rows="1"
+    bind:this={textareaEl}
+    placeholder="Type a message"
+  ></textarea>
+  <button
+    class="btn bg-primary text-primary-foreground px-4 py-2 rounded-md"
+    on:click={send}
+  >
+    Send
+  </button>
+</div>

--- a/src/lib/components/chat/MessageItem.svelte
+++ b/src/lib/components/chat/MessageItem.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import type { Message } from '$lib/stores/messages';
+
+  // Message data passed from the parent component
+  export let message: Message;
+
+  // Determine alignment and colors based on the sender
+  const isUser = message.role === 'user';
+</script>
+
+<!-- Wrapper aligns left or right depending on the role -->
+<div class="flex my-2" class:justify-end={isUser} class:justify-start={!isUser}>
+  <div
+    class="rounded-lg p-3 max-w-[80%] break-words text-sm sm:text-base"
+    class:bg-primary={isUser}
+    class:text-primary-foreground={isUser}
+    class:bg-muted={!isUser}
+    class:text-muted-foreground={!isUser}
+  >
+    {message.content}
+  </div>
+</div>

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+  // Import the main chat component
+  import Chat from '$lib/components/chat/Chat.svelte';
+</script>
+
+<!-- Chat page simply renders the Chat component -->
+<Chat />


### PR DESCRIPTION
## Summary
- implement Chat page component wrapper
- build Chat layout with scrolling messages and input
- create MessageItem for chat bubbles
- create MessageInput for chat form

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_686509a01930832b9af103d5698b54ea