### PR TITLE
Style restaurant chat UI

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  // Svelte helpers
+  // Svelte helpers used for scrolling
   import { tick } from 'svelte';
 
   // Chat message store and helper function
@@ -9,11 +9,8 @@
   import MessageItem from './MessageItem.svelte';
   import MessageInput from './MessageInput.svelte';
 
-  // Skeleton does not ship a container component, but we apply
-  // its container classes to a regular div
-
-  // Hard coded identifiers for now. In a real app these
-  // would come from the router or a store.
+  // Hard coded identifiers for now. In a real app
+  // these would come from the router or a store.
   const chatId = 'chat-001';
   const userId = 'user-abc';
 
@@ -35,19 +32,37 @@
 </script>
 
 <!-- Full screen chat container -->
-<div class="container flex flex-col h-screen max-w-screen-md mx-auto">
+<div class="h-screen flex flex-col max-w-screen-md mx-auto rounded-xl shadow-md bg-background border border-border">
+  <!-- Header with avatar, title and actions -->
+  <div class="flex items-center justify-between px-4 py-3 border-b border-border">
+    <div class="flex items-center gap-2">
+      <!-- Placeholder avatar -->
+      <div class="w-8 h-8 rounded-full bg-warning-500 flex items-center justify-center font-bold text-neutral-950">B</div>
+      <span class="font-bold">Restaurant Bot</span>
+    </div>
+    <div class="flex items-center gap-2 text-muted-foreground">
+      <button class="btn-icon" aria-label="Refresh">🔄</button>
+      <button class="btn-icon" aria-label="Expand">⤢</button>
+    </div>
+  </div>
+
+  <!-- Date label -->
+  <div class="flex items-center gap-2 px-4 py-1 text-sm text-muted-foreground">
+    <div class="flex-1 h-px bg-border"></div>
+    <span>{new Date().toLocaleDateString()}</span>
+    <div class="flex-1 h-px bg-border"></div>
+  </div>
+
   <!-- Messages list -->
-  <div
-    class="overflow-y-auto px-4 py-2 flex-1"
-    bind:this={listEl}
-  >
+  <div class="overflow-y-auto px-4 py-2 flex-1" bind:this={listEl}>
     {#each $messages as message (message.id)}
       <MessageItem {message} />
     {/each}
   </div>
 
-  <!-- Input area -->
-  <div class="sticky bottom-0 z-10 bg-background px-4 py-3">
+  <!-- Input and footer -->
+  <div class="sticky bottom-0 z-10 bg-background px-4 py-3 space-y-2">
     <MessageInput on:send={handleSend} />
+    <div class="text-center text-xs text-muted-foreground">Powered by sendbird</div>
   </div>
 </div>

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -2,7 +2,6 @@
   import { createEventDispatcher } from 'svelte';
 
   // We use Skeleton's styling classes on native elements
-
   // Dispatcher emits the input string when a message is sent
   const dispatch = createEventDispatcher<{ send: string }>();
 
@@ -37,18 +36,15 @@
 <!-- Input area with textarea and send button -->
 <div class="flex gap-2">
   <textarea
-    class="flex-1 rounded-md p-2 border bg-background text-sm sm:text-base"
+    class="textarea flex-1 rounded-full bg-surface-200 text-sm sm:text-base shadow-inner p-2"
     bind:value={input}
     on:input={resize}
     on:keydown={handleKeydown}
     rows="1"
     bind:this={textareaEl}
-    placeholder="Type a message"
+    placeholder="Enter message"
   ></textarea>
-  <button
-    class="btn bg-primary text-primary-foreground px-4 py-2 rounded-md"
-    on:click={send}
-  >
+  <button class="btn bg-primary text-primary-foreground" on:click={send}>
     Send
   </button>
 </div>

--- a/src/lib/components/chat/MessageItem.svelte
+++ b/src/lib/components/chat/MessageItem.svelte
@@ -1,25 +1,32 @@
 <script lang="ts">
   import type { Message } from '$lib/stores/messages';
 
-  // Each message is displayed in a small card-like container
-
   // Message data passed from the parent component
   export let message: Message;
 
-  // Determine alignment and colors based on the sender
+  // Check if the sender is the user or the assistant
   const isUser = message.role === 'user';
+
+  // Format timestamp for display
+  function timeLabel(date: string) {
+    return new Date(date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+  }
 </script>
 
 <!-- Wrapper aligns left or right depending on the sender -->
 <div class="flex my-2" class:justify-end={isUser} class:justify-start={!isUser}>
-  <div
-    class="rounded-xl p-3 max-w-[80%] break-words text-sm sm:text-base"
-    class:bg-primary={isUser}
-    class:text-primary-foreground={isUser}
-    class:bg-muted={!isUser}
-    class:text-muted-foreground={!isUser}
-  >
-    <!-- Display the message content -->
-    {message.content}
+  <div class="flex items-end" class:flex-row-reverse={isUser}>
+    <!-- Bubble -->
+    <div
+      class="px-4 py-2 rounded-full max-w-[80%] break-words text-sm sm:text-base shadow"
+      class:bg-neutral-800={isUser}
+      class:text-neutral-50={isUser}
+      class:bg-warning-200={!isUser}
+      class:text-neutral-900={!isUser}
+    >
+      {message.content}
+    </div>
+    <!-- Timestamp -->
+    <span class="px-2 text-xs text-neutral-500">{timeLabel(message.createdAt)}</span>
   </div>
 </div>

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
-  // Import the main chat component
+  // The Chat component contains the full interface
   import Chat from '$lib/components/chat/Chat.svelte';
 </script>
 
-<!-- Chat page simply renders the Chat component -->
+<!-- Simply render the chat -->
 <Chat />


### PR DESCRIPTION
## Summary
- style chat page to mimic Sendbird look
- add avatar header and date label in Chat component
- style message bubbles with timestamps
- update message input with rounded textarea

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_6865141e96c4832ba80e6218a3c626f9