### PR TITLE
Implement SoundForge style chat UI

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.1",
 			"dependencies": {
 				"@tailwindcss/vite": "^4.1.11",
+				"lucide-svelte": "^0.525.0",
 				"tailwindcss": "^4.1.11",
 				"zod": "^3.25.67"
 			},
@@ -765,7 +766,6 @@
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.5.tgz",
 			"integrity": "sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==",
-			"dev": true,
 			"peerDependencies": {
 				"acorn": "^8.9.0"
 			}
@@ -1513,7 +1513,6 @@
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
-			"dev": true,
 			"bin": {
 				"acorn": "bin/acorn"
 			},
@@ -1525,7 +1524,6 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
 			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -1534,7 +1532,6 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
 			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
-			"dev": true,
 			"engines": {
 				"node": ">= 0.4"
 			}
@@ -1566,7 +1563,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
 			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-			"dev": true,
 			"engines": {
 				"node": ">=6"
 			}
@@ -1680,14 +1676,12 @@
 		"node_modules/esm-env": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
-			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
-			"dev": true
+			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="
 		},
 		"node_modules/esrap": {
 			"version": "1.4.9",
 			"resolved": "https://registry.npmjs.org/esrap/-/esrap-1.4.9.tgz",
 			"integrity": "sha512-3OMlcd0a03UGuZpPeUC1HxR3nA23l+HEyCiZw3b3FumJIN9KphoGzDJKMXI1S72jVS1dsenDyQC0kJlO1U9E1g==",
-			"dev": true,
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
 			}
@@ -1727,7 +1721,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
 			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
-			"dev": true,
 			"dependencies": {
 				"@types/estree": "^1.0.6"
 			}
@@ -1969,8 +1962,16 @@
 		"node_modules/locate-character": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
-			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
-			"dev": true
+			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="
+		},
+		"node_modules/lucide-svelte": {
+			"version": "0.525.0",
+			"resolved": "https://registry.npmjs.org/lucide-svelte/-/lucide-svelte-0.525.0.tgz",
+			"integrity": "sha512-kfuN6JcCqTfCz2B76aXnyGLAzEBRSYw5GaUspM5RNHQZS5aI5yaKu06fbaofOk8cDvUtY0AUm/zAix7aUX6Q3A==",
+			"license": "ISC",
+			"peerDependencies": {
+				"svelte": "^3 || ^4 || ^5.0.0-next.42"
+			}
 		},
 		"node_modules/magic-string": {
 			"version": "0.30.17",
@@ -2198,7 +2199,6 @@
 			"version": "5.34.9",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.34.9.tgz",
 			"integrity": "sha512-sld35zFpooaSRSj4qw8Vl/cyyK0/sLQq9qhJ7BGZo/Kd0ggYtEnvNYLlzhhoqYsYQzA0hJqkzt3RBO/8KoTZOg==",
-			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.3.0",
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -2410,8 +2410,7 @@
 		"node_modules/zimmerframe": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.2.tgz",
-			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w==",
-			"dev": true
+			"integrity": "sha512-rAbqEGa8ovJy4pyBxZM70hg4pE6gDgaQ0Sl9M3enG3I0d6H4XSAM3GeNGLKnsBpuijUow064sf7ww1nutC5/3w=="
 		},
 		"node_modules/zod": {
 			"version": "3.25.67",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 	},
 	"dependencies": {
 		"@tailwindcss/vite": "^4.1.11",
+		"lucide-svelte": "^0.525.0",
 		"tailwindcss": "^4.1.11",
 		"zod": "^3.25.67"
 	}

--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -2,12 +2,15 @@
   // Svelte helpers used for scrolling
   import { tick } from 'svelte';
 
-  // Chat message store and helper function
+  // Shared message store and helper to send a new message
   import { messages, sendMessage } from '$lib/stores/messages';
 
   // Child components
   import MessageItem from './MessageItem.svelte';
   import MessageInput from './MessageInput.svelte';
+
+  // Simple icons from Lucide
+  import { Menu, RefreshCw } from 'lucide-svelte';
 
   // Hard coded identifiers for now. In a real app
   // these would come from the router or a store.
@@ -31,38 +34,27 @@
   }
 </script>
 
-<!-- Full screen chat container -->
-<div class="h-screen flex flex-col max-w-screen-md mx-auto rounded-xl shadow-md bg-background border border-border">
-  <!-- Header with avatar, title and actions -->
-  <div class="flex items-center justify-between px-4 py-3 border-b border-border">
-    <div class="flex items-center gap-2">
-      <!-- Placeholder avatar -->
-      <div class="w-8 h-8 rounded-full bg-warning-500 flex items-center justify-center font-bold text-neutral-950">B</div>
-      <span class="font-bold">Restaurant Bot</span>
-    </div>
-    <div class="flex items-center gap-2 text-muted-foreground">
-      <button class="btn-icon" aria-label="Refresh">🔄</button>
-      <button class="btn-icon" aria-label="Expand">⤢</button>
-    </div>
+<!-- Outer container for the chat -->
+<div class="h-screen flex flex-col max-w-screen-md mx-auto">
+  <!-- Top bar with simple actions -->
+  <div class="flex items-center justify-between px-4 py-3 backdrop-blur-lg bg-white/5 border-b border-white/10">
+    <button aria-label="Menu" class="p-2 text-white/60 hover:text-white">
+      <Menu class="w-5 h-5" />
+    </button>
+    <button aria-label="Refresh" class="p-2 text-white/60 hover:text-white">
+      <RefreshCw class="w-5 h-5" />
+    </button>
   </div>
 
-  <!-- Date label -->
-  <div class="flex items-center gap-2 px-4 py-1 text-sm text-muted-foreground">
-    <div class="flex-1 h-px bg-border"></div>
-    <span>{new Date().toLocaleDateString()}</span>
-    <div class="flex-1 h-px bg-border"></div>
-  </div>
-
-  <!-- Messages list -->
-  <div class="overflow-y-auto px-4 py-2 flex-1" bind:this={listEl}>
+  <!-- Scrollable messages area -->
+  <div class="flex-1 overflow-y-auto px-4 py-4 space-y-4" bind:this={listEl}>
     {#each $messages as message (message.id)}
       <MessageItem {message} />
     {/each}
   </div>
 
-  <!-- Input and footer -->
-  <div class="sticky bottom-0 z-10 bg-background px-4 py-3 space-y-2">
+  <!-- Message input bar -->
+  <div class="sticky bottom-0 z-10 backdrop-blur-lg bg-white/5 px-4 py-4">
     <MessageInput on:send={handleSend} />
-    <div class="text-center text-xs text-muted-foreground">Powered by sendbird</div>
   </div>
 </div>

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
+  import { Send } from 'lucide-svelte';
 
-  // We use Skeleton's styling classes on native elements
   // Dispatcher emits the input string when a message is sent
   const dispatch = createEventDispatcher<{ send: string }>();
 
@@ -14,7 +14,7 @@
     textareaEl.style.height = textareaEl.scrollHeight + 'px';
   }
 
-  // Handle keyboard shortcuts
+  // Handle Enter to send and Shift+Enter for newline
   function handleKeydown(event: KeyboardEvent) {
     if (event.key === 'Enter' && !event.shiftKey) {
       event.preventDefault();
@@ -34,17 +34,21 @@
 </script>
 
 <!-- Input area with textarea and send button -->
-<div class="flex gap-2">
+<div class="flex items-end gap-2">
   <textarea
-    class="textarea flex-1 rounded-full bg-surface-200 text-sm sm:text-base shadow-inner p-2"
+    class="flex-1 resize-none rounded-full bg-slate-800 border border-white/10 text-sm text-white px-4 py-2 placeholder-white/40 focus:outline-none"
     bind:value={input}
     on:input={resize}
     on:keydown={handleKeydown}
     rows="1"
     bind:this={textareaEl}
-    placeholder="Enter message"
+    placeholder="Type your message"
   ></textarea>
-  <button class="btn bg-primary text-primary-foreground" on:click={send}>
-    Send
+  <button
+    class="p-2 text-white hover:text-yellow-400"
+    aria-label="Send"
+    on:click={send}
+  >
+    <Send class="w-5 h-5" />
   </button>
 </div>

--- a/src/lib/components/chat/MessageItem.svelte
+++ b/src/lib/components/chat/MessageItem.svelte
@@ -9,24 +9,27 @@
 
   // Format timestamp for display
   function timeLabel(date: string) {
-    return new Date(date).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+    return new Date(date).toLocaleTimeString([], {
+      hour: '2-digit',
+      minute: '2-digit'
+    });
   }
 </script>
 
 <!-- Wrapper aligns left or right depending on the sender -->
 <div class="flex my-2" class:justify-end={isUser} class:justify-start={!isUser}>
-  <div class="flex items-end" class:flex-row-reverse={isUser}>
-    <!-- Bubble -->
+  <div class="max-w-[75%] flex flex-col" class:items-end={isUser} class:items-start={!isUser}>
+    <!-- Bubble showing the message content -->
     <div
-      class="px-4 py-2 rounded-full max-w-[80%] break-words text-sm sm:text-base shadow"
-      class:bg-neutral-800={isUser}
-      class:text-neutral-50={isUser}
-      class:bg-warning-200={!isUser}
-      class:text-neutral-900={!isUser}
+      class="px-4 py-2 rounded-xl border border-white/10 backdrop-blur-lg break-words"
+      class:bg-slate-800={isUser}
+      class:text-white={isUser}
+      class:bg-yellow-400={!isUser}
+      class:text-black={!isUser}
     >
       {message.content}
     </div>
-    <!-- Timestamp -->
-    <span class="px-2 text-xs text-neutral-500">{timeLabel(message.createdAt)}</span>
+    <!-- Optional time label -->
+    <span class="mt-1 text-xs text-white/40">{timeLabel(message.createdAt)}</span>
   </div>
 </div>

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -1,7 +1,21 @@
 <script lang="ts">
-  // The Chat component contains the full interface
+  // Import the chat interface component
   import Chat from '$lib/components/chat/Chat.svelte';
 </script>
 
-<!-- Simply render the chat -->
-<Chat />
+<!-- Load the Inter font -->
+<svelte:head>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+    rel="stylesheet"
+  />
+</svelte:head>
+
+<!-- Wrap everything in a gradient background -->
+<main
+  class="font-inter bg-gradient-to-br from-[#0f172a] via-[#1e293b] to-[#0c1425] text-white min-h-screen"
+>
+  <Chat />
+</main>


### PR DESCRIPTION
## Summary
- apply Inter font and gradient background to chat page
- update Chat component layout and header icons
- restyle MessageItem bubbles
- add Lucide icons and better textarea styling for MessageInput
- install lucide-svelte

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_6865189237f8832bbb073077e77b8a79