### PR TITLE
Implement brutalist chat UI

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -10,7 +10,6 @@
   import MessageInput from './MessageInput.svelte';
 
   // Simple icons from Lucide
-  import { Menu, RefreshCw } from 'lucide-svelte';
 
   // Hard coded identifiers for now. In a real app
   // these would come from the router or a store.
@@ -35,26 +34,19 @@
 </script>
 
 <!-- Outer container for the chat -->
-<div class="h-screen flex flex-col max-w-screen-md mx-auto">
-  <!-- Top bar with simple actions -->
-  <div class="flex items-center justify-between px-4 py-3 backdrop-blur-lg bg-white/5 border-b border-white/10">
-    <button aria-label="Menu" class="p-2 text-white/60 hover:text-white">
-      <Menu class="w-5 h-5" />
-    </button>
-    <button aria-label="Refresh" class="p-2 text-white/60 hover:text-white">
-      <RefreshCw class="w-5 h-5" />
-    </button>
-  </div>
+<div class="grid grid-rows-[auto_1fr_auto] min-h-screen border-8 border-black">
+  <!-- Heading bar -->
+  <div class="text-3xl font-bold uppercase border-b-8 border-black p-4">BRUTAL BOT</div>
 
   <!-- Scrollable messages area -->
-  <div class="flex-1 overflow-y-auto px-4 py-4 space-y-4" bind:this={listEl}>
+  <div class="overflow-y-auto flex-1 p-4 space-y-4" bind:this={listEl}>
     {#each $messages as message (message.id)}
       <MessageItem {message} />
     {/each}
   </div>
 
   <!-- Message input bar -->
-  <div class="sticky bottom-0 z-10 backdrop-blur-lg bg-white/5 px-4 py-4">
+  <div class="sticky bottom-0 border-t-8 border-black bg-white p-4">
     <MessageInput on:send={handleSend} />
   </div>
 </div>

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { createEventDispatcher } from 'svelte';
-  import { Send } from 'lucide-svelte';
 
   // Dispatcher emits the input string when a message is sent
   const dispatch = createEventDispatcher<{ send: string }>();
@@ -34,21 +33,20 @@
 </script>
 
 <!-- Input area with textarea and send button -->
-<div class="flex items-end gap-2">
+<div class="flex gap-4">
   <textarea
-    class="flex-1 resize-none rounded-full bg-slate-800 border border-white/10 text-sm text-white px-4 py-2 placeholder-white/40 focus:outline-none"
+    class="border-8 border-black px-4 py-3 w-full font-plex focus:outline-none resize-none"
     bind:value={input}
+    bind:this={textareaEl}
     on:input={resize}
     on:keydown={handleKeydown}
     rows="1"
-    bind:this={textareaEl}
-    placeholder="Type your message"
+    placeholder="TYPE HERE"
   ></textarea>
   <button
-    class="p-2 text-white hover:text-yellow-400"
-    aria-label="Send"
+    class="bg-black text-white font-bold uppercase px-6 py-3 border-8 border-black hover:bg-white hover:text-black"
     on:click={send}
   >
-    <Send class="w-5 h-5" />
+    SEND
   </button>
 </div>

--- a/src/lib/components/chat/MessageItem.svelte
+++ b/src/lib/components/chat/MessageItem.svelte
@@ -17,19 +17,20 @@
 </script>
 
 <!-- Wrapper aligns left or right depending on the sender -->
-<div class="flex my-2" class:justify-end={isUser} class:justify-start={!isUser}>
-  <div class="max-w-[75%] flex flex-col" class:items-end={isUser} class:items-start={!isUser}>
-    <!-- Bubble showing the message content -->
+<div class="flex mb-4" class:justify-end={isUser} class:justify-start={!isUser}>
+  <div class="flex flex-col" class:items-end={isUser} class:items-start={!isUser}>
+    <!-- Bubble with sender label and message -->
     <div
-      class="px-4 py-2 rounded-xl border border-white/10 backdrop-blur-lg break-words"
-      class:bg-slate-800={isUser}
+      class="border-8 border-black p-4 max-w-[70%] break-words"
+      class:bg-black={isUser}
       class:text-white={isUser}
-      class:bg-yellow-400={!isUser}
+      class:bg-white={!isUser}
       class:text-black={!isUser}
     >
-      {message.content}
+      <span class="text-sm uppercase font-bold">{isUser ? 'YOU' : 'BOT'}</span>
+      <div class="mt-2">{message.content}</div>
     </div>
-    <!-- Optional time label -->
-    <span class="mt-1 text-xs text-white/40">{timeLabel(message.createdAt)}</span>
+    <!-- Timestamp below -->
+    <span class="text-xs mt-1">{timeLabel(message.createdAt)}</span>
   </div>
 </div>

--- a/src/routes/chat/+page.svelte
+++ b/src/routes/chat/+page.svelte
@@ -3,19 +3,17 @@
   import Chat from '$lib/components/chat/Chat.svelte';
 </script>
 
-<!-- Load the Inter font -->
+<!-- Load IBM Plex Mono font for the brutalist look -->
 <svelte:head>
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin="anonymous" />
   <link
-    href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+    href="https://fonts.googleapis.com/css2?family=IBM+Plex+Mono:wght@400;700&display=swap"
     rel="stylesheet"
   />
 </svelte:head>
 
-<!-- Wrap everything in a gradient background -->
-<main
-  class="font-inter bg-gradient-to-br from-[#0f172a] via-[#1e293b] to-[#0c1425] text-white min-h-screen"
->
+<!-- Brutalist white on black layout -->
+<main class="min-h-screen flex flex-col bg-white text-black font-plex">
   <Chat />
 </main>


### PR DESCRIPTION
## Summary
- update chat page styles for brutalist design
- refactor chat layout and remove icons
- adjust message item markup
- redesign message input field

## Testing
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68651b5291ac832b8eda51cf3f1f10b0