### PR TITLE
Fix chat UI width and autoscroll

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   // Svelte helpers used for scrolling
-  import { tick } from 'svelte';
+  import { tick, afterUpdate } from 'svelte';
 
   // Shared message store and helper to send a new message
   import { messages, sendMessage } from '$lib/stores/messages';
@@ -18,13 +18,16 @@
 
   // Reference to the scrolling container so we can
   // keep the newest messages in view
-  let listEl: HTMLDivElement;
+  let scrollEl: HTMLDivElement;
 
-  // Scroll to the bottom whenever messages change
-  $: scrollToBottom();
+  // Automatically scroll to the bottom after each update
+  afterUpdate(scrollToBottom);
   async function scrollToBottom() {
     await tick();
-    listEl?.scrollTo({ top: listEl.scrollHeight, behavior: 'smooth' });
+    if (scrollEl) {
+      // Set scroll position to the bottom of the list
+      scrollEl.scrollTop = scrollEl.scrollHeight;
+    }
   }
 
   // Forward sent messages to the store
@@ -39,7 +42,7 @@
   <div class="text-3xl font-bold uppercase border-b-8 border-black p-4">BRUTAL BOT</div>
 
   <!-- Scrollable messages area -->
-  <div class="overflow-y-auto flex-1 p-4 space-y-4" bind:this={listEl}>
+  <div class="overflow-y-auto flex-1 p-4 space-y-4" bind:this={scrollEl}>
     {#each $messages as message (message.id)}
       <MessageItem {message} />
     {/each}

--- a/src/lib/components/chat/MessageInput.svelte
+++ b/src/lib/components/chat/MessageInput.svelte
@@ -33,9 +33,10 @@
 </script>
 
 <!-- Input area with textarea and send button -->
-<div class="flex gap-4">
+<!-- Flex keeps textarea and button vertically centered -->
+<div class="flex items-center gap-4">
   <textarea
-    class="border-8 border-black px-4 py-3 w-full font-plex focus:outline-none resize-none"
+    class="border-8 border-black px-4 py-3 w-full font-plex focus:outline-none resize-none leading-none align-middle min-h-[48px]"
     bind:value={input}
     bind:this={textareaEl}
     on:input={resize}

--- a/src/lib/components/chat/MessageItem.svelte
+++ b/src/lib/components/chat/MessageItem.svelte
@@ -19,16 +19,16 @@
 <!-- Wrapper aligns left or right depending on the sender -->
 <div class="flex mb-4" class:justify-end={isUser} class:justify-start={!isUser}>
   <div class="flex flex-col" class:items-end={isUser} class:items-start={!isUser}>
-    <!-- Bubble with sender label and message -->
+    <!-- Bubble containing the message text -->
     <div
-      class="border-8 border-black p-4 max-w-[70%] break-words"
+      class="border-8 border-black p-4 max-w-[80%] break-words whitespace-pre-wrap"
       class:bg-black={isUser}
       class:text-white={isUser}
       class:bg-white={!isUser}
       class:text-black={!isUser}
     >
-      <span class="text-sm uppercase font-bold">{isUser ? 'YOU' : 'BOT'}</span>
-      <div class="mt-2">{message.content}</div>
+      <!-- Actual chat content -->
+      <div class="text-base">{message.content}</div>
     </div>
     <!-- Timestamp below -->
     <span class="text-xs mt-1">{timeLabel(message.createdAt)}</span>


### PR DESCRIPTION
## Summary
- enlarge chat bubbles and wrap better
- auto-scroll to the latest message
- keep message input vertically centered
- clean up message labels

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_68651e452c4c832ba404c1a9f610c2a9