### PR TITLE
Refactor chat scroll logic

### DIFF
--- a/src/lib/components/chat/Chat.svelte
+++ b/src/lib/components/chat/Chat.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
-  import { tick } from 'svelte';
+  import { afterUpdate, tick } from 'svelte';
+  import { get } from 'svelte/store';
   import { messages, sendMessage } from '$lib/stores/messages';
   import MessageItem from './MessageItem.svelte';
   import MessageInput from './MessageInput.svelte';
@@ -8,16 +9,21 @@
   const userId = 'user-abc';
 
   let scrollEl: HTMLDivElement;
+  // keep track of the number of rendered messages to avoid scrolling on every update
+  let lastCount = 0;
 
-  // Reactive effect: scroll to bottom when $messages updates
-  $: if (scrollEl) {
-    scrollToBottom();
-  }
-
-  async function scrollToBottom() {
+  // Scroll to the bottom whenever a new message is rendered
+  afterUpdate(async () => {
+    const currentCount = get(messages).length;
+    if (!scrollEl || currentCount === lastCount) return;
+    lastCount = currentCount;
     await tick();
-    scrollEl.scrollTop = scrollEl.scrollHeight;
-  }
+    requestAnimationFrame(() => {
+      if (scrollEl) {
+        scrollEl.scrollTop = scrollEl.scrollHeight;
+      }
+    });
+  });
 
   function handleSend(event: CustomEvent<string>) {
     sendMessage(event.detail, chatId, userId);
@@ -31,6 +37,7 @@
   <div class="text-3xl font-bold uppercase border-b-8 border-black p-4">BRUTAL BOT</div>
 
   <!-- Scrollable messages area -->
+  <!-- If messages become very long, consider lazy-loading older items here -->
   <div class="overflow-y-auto flex-1 p-4 space-y-4" bind:this={scrollEl}>
     {#each $messages as message (message.id)}
       <MessageItem {message} />


### PR DESCRIPTION
## Summary
- use `afterUpdate` to scroll when new messages appear
- keep track of message count to avoid unnecessary scrolling
- prepare for lazy loading message list

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686523ea4950832bbccba00571e8623a